### PR TITLE
feat: golden numbers

### DIFF
--- a/app/repositories/doc_numbers.py
+++ b/app/repositories/doc_numbers.py
@@ -13,6 +13,13 @@ class DocNumbersRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
 
+    async def find_existing_from_list(self, numbers: list[int]) -> set[int]:
+        if not numbers:
+            return set()
+        query = select(DocNumber.numeric).where(DocNumber.numeric.in_(numbers))
+        result = await self.session.execute(query)
+        return set(result.scalars().all())
+
     async def release_expired(self, now: datetime | None = None) -> int:
         now = now or datetime.utcnow()
         res = await self.session.execute(

--- a/app/schemas/documents.py
+++ b/app/schemas/documents.py
@@ -24,3 +24,15 @@ class DocumentOut(BaseModel):
 
     class Config:
         from_attributes = True
+
+class GoldenNumberReservationRequest(BaseModel):
+    """Схема для запроса на резервирование 'золотых' номеров."""
+    quantity: int = Field(..., gt=0, description="Количество золотых номеров для резервирования.")
+    equipment_id: int = Field(..., description="ID оборудования, к которому будут привязаны номера.")
+    ttl_seconds: int = Field(default=3600, gt=0, description="Время жизни резервации в секундах.")
+
+
+class GoldenNumberReservationResponse(BaseModel):
+    """Схема для ответа после резервирования 'золотых' номеров."""
+    session_id: str
+    reserved_numbers: list[int]

--- a/app/services/reservation.py
+++ b/app/services/reservation.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from sqlalchemy import update
+from sqlalchemy import update, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import HTTPException, status
 
 from app.models.doc_number import DocNumber
 from app.repositories.sessions import SessionsRepository
 from app.repositories.doc_numbers import DocNumbersRepository
 from app.repositories.counter import CounterRepository
 from app.models.session import SessionStatus, Session
+
 from app.utils.numbering import is_golden
 
+MAX_DOCUMENT_NUMBER = 999999
 
 class ReservationService:
     def __init__(self, session: AsyncSession):
@@ -19,6 +22,69 @@ class ReservationService:
         self.sessions_repo = SessionsRepository(session)
         self.numbers_repo = DocNumbersRepository(session)
         self.counter_repo = CounterRepository(session)
+
+    async def reserve_golden_numbers(
+        self, *, user_id: int, equipment_id: int, quantity: int, ttl_seconds: int
+    ) -> tuple[str, list[int]]:
+        """
+        Находит и резервирует указанное количество свободных 'золотых' номеров,
+        учитывая максимальный предел.
+        """
+        counter = await self.counter_repo.get_for_update()
+        
+        # 1. Определяем, откуда начинать поиск
+        search_start = max(counter.base_start, counter.next_normal_start)
+        
+        # Находим первого 'золотого' кандидата после точки старта
+        current_candidate = (search_start + 99) // 100 * 100
+        if current_candidate < search_start:
+            current_candidate += 100
+        
+        found_numbers = []
+        batch_size = quantity * 2
+        
+        # 2. Ищем свободные номера пачками, пока не наберем достаточно или не достигнем предела
+        while len(found_numbers) < quantity and current_candidate <= MAX_DOCUMENT_NUMBER:
+            candidates_batch = []
+            batch_end = current_candidate + (batch_size * 100)
+            
+            temp_candidate = current_candidate
+            while temp_candidate < batch_end and len(candidates_batch) < batch_size:
+                if temp_candidate > MAX_DOCUMENT_NUMBER:
+                    break
+                candidates_batch.append(temp_candidate)
+                temp_candidate += 100
+            
+            if not candidates_batch:
+                break
+
+            existing_in_batch = await self.numbers_repo.find_existing_from_list(candidates_batch)
+            
+            for num in candidates_batch:
+                if num not in existing_in_batch:
+                    found_numbers.append(num)
+                    if len(found_numbers) == quantity:
+                        break
+            
+            current_candidate = candidates_batch[-1] + 100
+            if len(found_numbers) == quantity:
+                break
+
+        # 3. Теперь проверка на нехватку будет работать корректно
+        if len(found_numbers) < quantity:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Не удалось найти {quantity} свободных золотых номеров. Найдено только {len(found_numbers)}."
+            )
+        
+        # 4. Резервируем найденные номера
+        numbers_to_reserve = found_numbers[:quantity]
+        return await self.admin_reserve_specific(
+            user_id=user_id,
+            equipment_id=equipment_id,
+            numbers=numbers_to_reserve,
+            ttl_seconds=ttl_seconds
+        )
 
     async def start_session(self, *, user_id: int, equipment_id: int, requested_count: int, ttl_seconds: int) -> tuple[
         str, list[int]]:


### PR DESCRIPTION
### **Заголовок PR:** `feat(reservations): Упрощенный механизм резервирования "золотых" номеров`

### **Описание**

Этот Pull Request полностью перерабатывает и упрощает механизм резервирования "золотых" номеров (оканчивающихся на `00`), закрывая задачу **№7**.

Предыдущая реализация была запутанной и требовала от пользователя указывать конкретные номера или диапазоны. Новая логика соответствует стандартному процессу резервирования: пользователь просто указывает желаемое количество, а система сама находит и резервирует подходящие свободные номера.

В ходе разработки также был обнаружен и исправлен критический баг, при котором система могла зарезервировать бесконечное количество номеров, не имея верхнего предела.

**Связанная задача:** `Closes #7`

---

### **✨ Ключевые изменения**

1.  **Новый эндпоинт `POST /reserve-golden`:**
    -   Создан выделенный маршрут для резервирования "золотых" номеров.
    -   Доступ к эндпоинту предоставлен **только администраторам**. При попытке доступа обычным пользователем возвращается ошибка **403 Forbidden**.

2.  **Упрощенный запрос:**
    -   Создана новая схема `GoldenNumberReservationRequest`, которая требует от пользователя только три поля:
        -   `quantity` (обязательное): Количество "золотых" номеров.
        -   `equipment_id` (обязательное): ID оборудования для привязки сессии.
        -   `ttl_seconds` (опциональное): Время жизни резервации.

3.  **Новая логика в сервисе:**
    -   В `ReservationService` добавлен новый метод `reserve_golden_numbers`.
    -   Метод **автоматически находит** первые `N` свободных номеров, заканчивающихся на `00`, вместо того чтобы требовать их от пользователя.
    -   Для выполнения резервации переиспользуется уже существующий надежный метод `admin_reserve_specific`.

4.  **Исправление бага с неограниченным поиском:**
    -   **Проблема:** Предыдущая версия логики не имела верхнего предела для поиска номеров, что позволяло успешно запрашивать и резервировать тысячи номеров, выходящих за все разумные рамки.
    -   **Решение:** В сервис добавлена константа `MAX_DOCUMENT_NUMBER`. Алгоритм поиска теперь уважает этот предел и корректно возвращает ошибку **409 Conflict**, если не может найти достаточное количество свободных номеров в допустимом диапазоне.

---

### **📋 Как тестировать**

1.  **Успешный сценарий (Happy Path):**
    -   Будучи **администратором**, отправьте на `POST /reserve-golden` запрос:
        ```json
        { "quantity": 3, "equipment_id": 1 }
        ```
    -   **Ожидаемый результат:** Код ответа **201 Created** и JSON с `session_id` и списком из трех "золотых" номеров (например, `[100, 200, 300]`).

2.  **Тест прав доступа:**
    -   Временно измените в `app/core/auth.py` возврат на `is_admin=False`.
    -   Отправьте тот же самый запрос.
    -   **Ожидаемый результат:** Ошибка **403 Forbidden** с сообщением о нехватке прав.
    -   *(Не забудьте вернуть `is_admin=True`)*.

3.  **Тест на нехватку номеров (Проверка багфикса):**
    -   Будучи администратором, отправьте запрос с заведомо большим количеством:
        ```json
        { "quantity": 9999, "equipment_id": 1 }
        ```
    -   **Ожидаемый результат:** Ошибка **409 Conflict** с сообщением "Не удалось найти 9999 свободных золотых номеров. Найдено только X.". Это подтверждает, что ограничение `MAX_DOCUMENT_NUMBER` работает.

4.  **Тест валидации Pydantic:**
    -   Отправьте запрос с `quantity: 0` или без обязательного поля `equipment_id`.
    -   **Ожидаемый результат:** Ошибка **422 Unprocessable Entity** с детальным описанием проблемы.