### PR TITLE
feat: реализовать сохранение выбранной темы (светлая/темная)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,19 @@
 <template>
-  <router-view />
+  <v-app>
+    <router-view />
+  </v-app>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useTheme } from 'vuetify'
 
-<style scoped></style>
+const theme = useTheme()
+
+onMounted(() => {
+  const savedTheme = localStorage.getItem('utz-theme')
+  if (savedTheme && (savedTheme === 'utzDarkTheme' || savedTheme === 'utzLightTheme')) {
+    theme.global.name.value = savedTheme
+  }
+})
+</script>

--- a/frontend/src/components/ThemeToggleButton.vue
+++ b/frontend/src/components/ThemeToggleButton.vue
@@ -15,7 +15,16 @@ import { useTheme } from 'vuetify'
 const theme = useTheme()
 
 function toggleTheme() {
-  theme.global.name.value =
-    theme.global.name.value === 'utzDarkTheme' ? 'utzLightTheme' : 'utzDarkTheme'
+  const current = theme.global.name.value
+  const next = current === 'utzDarkTheme' ? 'utzLightTheme' : 'utzDarkTheme'
+
+  // 1. Применяем тему
+  theme.global.name.value = next
+
+  // 2. Сохраняем в LocalStorage
+  localStorage.setItem('utz-theme', next)
+  
+  // Для проверки можно оставить лог, потом уберешь
+  console.log('Theme saved:', next) 
 }
 </script>


### PR DESCRIPTION
Теперь выбор темы сохраняется в localStorage браузера и не сбрасывается при перезагрузке страницы.

Изменения:
1. frontend/src/components/ThemeToggleButton.vue:
   - Добавлена запись ключа `utz-theme` в localStorage при переключении темы.

2. frontend/src/App.vue:
   - Добавлен хук `onMounted`, который проверяет наличие сохраненной темы при запуске и применяет её.
   - Корневой элемент обернут в `<v-app>` для корректной отрисовки фона при смене темы.